### PR TITLE
👷 Stop building MLIR per default on PRs

### DIFF
--- a/.github/workflows/build-portable-mlir-toolchain.yml
+++ b/.github/workflows/build-portable-mlir-toolchain.yml
@@ -19,7 +19,8 @@ on:
         description: "Release notes for the GitHub release"
         required: true
         type: string
-  pull_request:
+  # Uncomment the following lines to enable the workflow on pull requests (e.g., for testing new build scripts)
+#  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
This PR removes the PR trigger for the MLIR builds, which just waste time in most cases.
For any experimentation on the builds themselves, the respective trigger can be uncommented.