### PR TITLE
🐛 Fix installation scripts to also accept commit SHAs

### DIFF
--- a/installation/setup-mlir.ps1
+++ b/installation/setup-mlir.ps1
@@ -52,8 +52,11 @@ $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
 # Determine whether version is version or commit SHA
 if ($llvm_version -match '^\d+\.\d+\.\d+$') {
     $match_pattern = "llvm-mlir_llvmorg-${llvm_version}_"
-} else {
+} elseif ($llvm_version -match '^[0-9a-f]{7,40}$') {
     $match_pattern = "llvm-mlir_${llvm_version}"
+} else {
+    Write-Error "Invalid LLVM version format: $llvm_version. Must be a version (e.g., 21.1.8) or a commit SHA."
+    exit 1
 }
 
 # Determine download URL

--- a/installation/setup-mlir.sh
+++ b/installation/setup-mlir.sh
@@ -79,8 +79,11 @@ esac
 # Determine whether version is version or commit SHA
 if [[ "$LLVM_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   MATCH_PATTERN="llvm-mlir_llvmorg-${LLVM_VERSION}_"
-else
+elif [[ "$LLVM_VERSION" =~ ^[0-9a-f]{7,40}$ ]]; then
   MATCH_PATTERN="llvm-mlir_${LLVM_VERSION}"
+else
+  echo "Error: Invalid LLVM version format: $LLVM_VERSION. Must be a version (e.g., 21.1.8) or a commit SHA." >&2
+  exit 1
 fi
 
 # Determine download URL


### PR DESCRIPTION
This PR updates the installation scripts to also accept commit SHAs. 