### PR TITLE
🔖 Prepare release of `v1.3.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ## [Unreleased]
 
-## [1.4.0] - 2026-05-18
+## [1.3.1] - 2026-05-18
 
 ### Added
 
@@ -82,8 +82,8 @@ _This is the initial release of the `setup-mlir` project._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-software/setup-mlir/compare/v1.4.0...HEAD
-[1.4.0]: https://github.com/munich-quantum-software/setup-mlir/releases/tag/v1.4.0
+[unreleased]: https://github.com/munich-quantum-software/setup-mlir/compare/v1.3.1...HEAD
+[1.3.1]: https://github.com/munich-quantum-software/setup-mlir/releases/tag/v1.3.1
 [1.3.0]: https://github.com/munich-quantum-software/setup-mlir/releases/tag/v1.3.0
 [1.2.1]: https://github.com/munich-quantum-software/setup-mlir/releases/tag/v1.2.1
 [1.2.0]: https://github.com/munich-quantum-software/setup-mlir/releases/tag/v1.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-05-18
+
+### Added
+
+- ✨ Add support for new LLVM versions ([#134], [#146], [#155], [#171], [#174], [#177])
+
 ## [1.3.0] - 2026-03-11
 
 ### Added
@@ -76,7 +82,8 @@ _This is the initial release of the `setup-mlir` project._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-software/setup-mlir/compare/v1.3.0...HEAD
+[unreleased]: https://github.com/munich-quantum-software/setup-mlir/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/munich-quantum-software/setup-mlir/releases/tag/v1.4.0
 [1.3.0]: https://github.com/munich-quantum-software/setup-mlir/releases/tag/v1.3.0
 [1.2.1]: https://github.com/munich-quantum-software/setup-mlir/releases/tag/v1.2.1
 [1.2.0]: https://github.com/munich-quantum-software/setup-mlir/releases/tag/v1.2.0
@@ -86,6 +93,12 @@ _This is the initial release of the `setup-mlir` project._
 
 <!-- PR links -->
 
+[#177]: https://github.com/munich-quantum-software/setup-mlir/pull/177
+[#174]: https://github.com/munich-quantum-software/setup-mlir/pull/174
+[#171]: https://github.com/munich-quantum-software/setup-mlir/pull/171
+[#155]: https://github.com/munich-quantum-software/setup-mlir/pull/155
+[#146]: https://github.com/munich-quantum-software/setup-mlir/pull/146
+[#134]: https://github.com/munich-quantum-software/setup-mlir/pull/134
 [#122]: https://github.com/munich-quantum-software/setup-mlir/pull/122
 [#111]: https://github.com/munich-quantum-software/setup-mlir/pull/111
 [#106]: https://github.com/munich-quantum-software/setup-mlir/pull/106

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For more information on the available LLVM versions and commit hashes, see [`ver
 
 ```yaml
 - name: Set up MLIR
-  uses: munich-quantum-software/setup-mlir@v1.3.0
+  uses: munich-quantum-software/setup-mlir@v1.3.1
   with:
     llvm-version: 22.1.0
 ```
@@ -43,7 +43,7 @@ On Windows, you can optionally install debug builds:
 
 ```yaml
 - name: Set up MLIR (Debug)
-  uses: munich-quantum-software/setup-mlir@v1.3.0
+  uses: munich-quantum-software/setup-mlir@v1.3.1
   with:
     llvm-version: 22.1.0
     debug: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-mlir",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-mlir",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "Apache-2.0 WITH LLVM-exception",
       "dependencies": {
         "@actions/core": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-mlir",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "GitHub Action that sets up a specific version of the MLIR toolchain",
   "main": "./dist/index.js",
   "scripts": {


### PR DESCRIPTION
This PR prepares the release of `v1.3.1`, which adds support for multiple new LLVM versions.